### PR TITLE
Fix chatbot streaming text element duplication

### DIFF
--- a/static/js/chatbot.js
+++ b/static/js/chatbot.js
@@ -660,16 +660,16 @@ class RiskOpsChatbot {
         botMessageDiv.innerHTML = `
             <div class="message-avatar">🤖</div>
             <div class="message-content">
-                <div class="message-text" id="streaming-text"></div>
+                <div class="message-text streaming-text"></div>
                 <div class="message-time">${new Date().toLocaleTimeString()}</div>
             </div>
         `;
-        
+
         this.hideTyping();
         messagesContainer.appendChild(botMessageDiv);
         messagesContainer.scrollTop = messagesContainer.scrollHeight;
-        
-        const streamingText = document.getElementById('streaming-text');
+
+        const streamingText = botMessageDiv.querySelector('.streaming-text');
         
         try {
             const url = `/api/chat/stream?message=${encodeURIComponent(message)}&session_id=${this.sessionId}`;


### PR DESCRIPTION
## Summary
- Ensure each chatbot response uses its own streaming text element to avoid message overlap
- Select the streaming text element via relative query to prevent future collisions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c603a3155c832d9933d2deab0185f0