### PR TITLE
Refine priority scoring and sync submissions

### DIFF
--- a/app.py
+++ b/app.py
@@ -1263,13 +1263,13 @@ def api_classified_mode():
     scounts = Counter(d["primary_risk_state"].fillna("UNK"))
     rows = []
     for r in d.to_dict(orient="records"):
-        stat, reasons, s, pscore = classify_for_mode_row(
+        stat, reasons, mscore, pscore = classify_for_mode_row(
             r, weights, filters, scounts
         )
         r["appetite_status"] = stat
         r["appetite_reasons"] = reasons
         r["priority_score"] = float(pscore)
-        r["mode_score"] = round(float(pscore), 4)
+        r["mode_score"] = round(float(mscore), 4)
         rows.append(sanitize_row(r))
 
     # Cut to top N% if provided in filters

--- a/guidelines.py
+++ b/guidelines.py
@@ -3,7 +3,7 @@ from typing import Dict, Tuple, List
 
 import numpy as np
 
-from scoring import score_row, sweet_spot, zscore, geo_penalty
+from scoring import score_row, sweet_spot, zscore, geo_penalty, compute_priority_score
 
 
 def _safe_float(x, default=np.nan):
@@ -149,13 +149,26 @@ def classify_for_mode_row(r: Dict, weights: Dict, filters: Dict, state_counts: D
         else:
             status = "IN"
 
-    # Composite priority calculation mirroring main app logic
-    priority_score = (
-        mode_score * 0.4
-        + comps["s_win"] * 10.0 * 0.3
-        + comps["s_prem"] * 10.0 * 0.2
-        + comps["s_fresh"] * 10.0 * 0.1
+    # Composite priority calculation using shared helper
+    priority_score = compute_priority_score(
+        mode_score,
+        comps["s_win"],
+        comps["s_prem"],
+        comps["s_fresh"],
     )
+
+    # Apply premium multiplier similar to main logic
+    premium = _safe_float(r.get("total_premium"))
+    premium_multiplier = 1.0
+    if not np.isnan(premium):
+        if 75_000 <= premium <= 100_000:
+            premium_multiplier = 1.3
+        elif 50_000 <= premium <= 175_000:
+            premium_multiplier = 1.1
+        if premium >= 1_000_000:
+            premium_multiplier *= 1.2
+
+    priority_score *= premium_multiplier
     priority_score = max(0.1, min(10.0, priority_score))
 
     return status, reasons, mode_score, priority_score

--- a/scoring.py
+++ b/scoring.py
@@ -47,3 +47,25 @@ def score_row(r, weights, state_counts):
     )
     penalty = geo_penalty(state_counts, r.get("primary_risk_state"))
     return max(0.0, base - penalty)
+
+
+def compute_priority_score(appetite: float, win_norm: float, prem_norm: float, fresh_norm: float) -> float:
+    """Blend core components into a 0-10 priority score.
+
+    Args:
+        appetite: Appetite or mode score on a 0-10 scale.
+        win_norm: Winnability normalized to 0-1.
+        prem_norm: Premium factor normalized to 0-1.
+        fresh_norm: Freshness factor normalized to 0-1.
+
+    Returns:
+        Priority score clamped to the 0-10 range.
+    """
+
+    priority = (
+        appetite * 0.4
+        + win_norm * 10.0 * 0.3
+        + prem_norm * 10.0 * 0.2
+        + fresh_norm * 10.0 * 0.1
+    )
+    return max(0.1, min(10.0, priority))

--- a/templates/index.html
+++ b/templates/index.html
@@ -421,6 +421,12 @@
                                 <span class="sort-icon">↕</span>
                             </div>
                         </th>
+                        <th class="th sortable" data-sort="mode_score">
+                            <div class="th-content">
+                                <span>Mode</span>
+                                <span class="sort-icon">↕</span>
+                            </div>
+                        </th>
                         <th class="th sortable" data-sort="priority_score">
                             <div class="th-content">
                                 <span>Priority</span>
@@ -433,7 +439,7 @@
                 <tbody id="acct_body" class="table-body">
                     <!-- Loading skeleton -->
                     <tr class="loading-row">
-                        <td colspan="7">
+                        <td colspan="8">
                             <div class="loading-content">
                                 <div class="skeleton-row" style="width: 100%; height: 3rem;"></div>
                                 <div class="skeleton-row" style="width: 95%; height: 2.5rem;"></div>
@@ -770,7 +776,7 @@
             // Show loading
             tbody.innerHTML = `
                 <tr class="loading-row">
-                    <td colspan="7">
+                    <td colspan="8">
                         <div class="loading-content">
                             <div class="skeleton-row" style="width: 100%; height: 3rem;"></div>
                             <div class="skeleton-row" style="width: 95%; height: 2.5rem;"></div>
@@ -801,7 +807,7 @@
             console.error('Error loading priority accounts:', error);
             tbody.innerHTML = `
                 <tr>
-                    <td colspan="7" class="text-center text-red-400 py-8">
+                    <td colspan="8" class="text-center text-red-400 py-8">
                         <div class="flex flex-col items-center gap-2">
                             <span class="text-2xl">⚠️</span>
                             <span>Failed to load priority accounts</span>
@@ -822,7 +828,7 @@
         if (!PRIORITY_ACCOUNTS_DATA.length) {
             tbody.innerHTML = `
                 <tr>
-                    <td colspan="7" class="text-center text-gray-400 py-8">
+                    <td colspan="8" class="text-center text-gray-400 py-8">
                         <div class="flex flex-col items-center gap-2">
                             <span class="text-3xl">🎯</span>
                             <span class="text-lg">No priority accounts found</span>
@@ -870,6 +876,9 @@
                     </td>
                     <td class="table-cell">
                         <span class="font-medium">${Math.round(account.winnability * 100)}%</span>
+                    </td>
+                    <td class="table-cell">
+                        <span class="font-medium">${account.mode_score.toFixed(1)}</span>
                     </td>
                     <td class="table-cell">
                         <span class="priority-score ${priorityClass} px-2 py-1 rounded-md text-xs font-bold">

--- a/templates/submissions.html
+++ b/templates/submissions.html
@@ -1355,6 +1355,7 @@ function applyPreset(preset) {
                     "tiv",
                     "winnability",
                     "priority_score",
+                    "mode_score",
                 ];
                 SORT_DIR = numeric.includes(key) ? "desc" : "asc";
             }
@@ -1743,6 +1744,7 @@ function applyPreset(preset) {
         winnability: row.winnability,
         appetite_status: row.appetite_status,
         priority_score: row.priority_score,
+        mode_score: row.mode_score,
       };
     }
     const ctl = startAutoRefresh({


### PR DESCRIPTION
## Summary
- normalize mode scoring and compute priority score with appetite, win, premium, and freshness inputs
- ensure classified mode API returns distinct mode and priority scores
- keep submissions table in sync by tracking `mode_score` and allowing sort

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c60b7c1dfc832d8f0e6a3bf0aab271