### PR TITLE
Format large numbers with thousand separators

### DIFF
--- a/app.py
+++ b/app.py
@@ -52,6 +52,16 @@ def dateformat(value, format='%b %d, %Y'):
     
     return '—'
 
+# Custom Jinja2 filter for comma formatting of large numbers
+@app.template_filter('commafy')
+def commafy(value, decimals=0):
+    """Format a number with thousands separators."""
+    try:
+        fmt = f"{float(value):,.{decimals}f}"
+        return fmt
+    except (TypeError, ValueError):
+        return value
+
 FEDERATO_TOKEN = os.environ.get("FEDERATO_TOKEN")
 CLIENT_ID = os.environ.get("FEDERATO_CLIENT_ID")
 CLIENT_SECRET = os.environ.get("FEDERATO_CLIENT_SECRET")

--- a/templates/detail.html
+++ b/templates/detail.html
@@ -42,11 +42,11 @@
   <!-- Quick Assessment Summary -->
   <div class="grid grid-cols-1 md:grid-cols-4 gap-4 p-4 bg-white bg-opacity-5 rounded-lg">
     <div class="text-center">
-      <div class="text-lg font-semibold text-emerald-300">${{ '%.0f'|format(item.total_premium or 0) }}</div>
+      <div class="text-lg font-semibold text-emerald-300">${{ item.total_premium | commafy }}</div>
       <div class="text-xs opacity-75">Premium</div>
     </div>
     <div class="text-center">
-      <div class="text-lg font-semibold">${{ (item.tiv / 1000000) | round(1) }}M</div>
+      <div class="text-lg font-semibold">${{ (item.tiv / 1000000) | commafy(1) }}M</div>
       <div class="text-xs opacity-75">TIV</div>
     </div>
     <div class="text-center">
@@ -93,7 +93,7 @@
         <div class="kv">
           <span>Loss Value</span>
           <b class="{% if item.loss_value > 100000 %}text-rose-300{% else %}text-emerald-300{% endif %}">
-            ${{ '%.0f'|format(item.loss_value or 0) }}
+            ${{ item.loss_value | commafy }}
           </b>
         </div>
         <div class="kv">

--- a/templates/index.html
+++ b/templates/index.html
@@ -74,10 +74,14 @@
       function updateQuickStats() {
         // This will be populated by the main script
         const metrics = window._dashboardMetrics || {};
-        document.getElementById('active_targets').textContent = metrics.targets || '—';
+        document.getElementById('active_targets').textContent =
+          metrics.targets ? Number(metrics.targets).toLocaleString() : '—';
         document.getElementById('win_rate').textContent = metrics.winRate ? Math.round(metrics.winRate) + '%' : '—%';
-        document.getElementById('avg_premium').textContent = metrics.avgPremium ? '$' + Math.round(metrics.avgPremium/1000) + 'K' : '—';
-        document.getElementById('opportunities_count').textContent = metrics.opportunities || '—';
+        document.getElementById('avg_premium').textContent = metrics.avgPremium
+          ? '$' + Math.round(metrics.avgPremium / 1000).toLocaleString() + 'K'
+          : '—';
+        document.getElementById('opportunities_count').textContent =
+          metrics.opportunities ? Number(metrics.opportunities).toLocaleString() : '—';
       }
       
       function simulateActivityFeed() {
@@ -905,7 +909,7 @@
         const nextBtn = document.getElementById('next_page');
         
         if (paginationInfo) {
-            paginationInfo.textContent = `Page ${PRIORITY_ACCOUNTS_PAGINATION.page} of ${PRIORITY_ACCOUNTS_PAGINATION.total_pages}`;
+            paginationInfo.textContent = `Page ${PRIORITY_ACCOUNTS_PAGINATION.page.toLocaleString()} of ${PRIORITY_ACCOUNTS_PAGINATION.total_pages.toLocaleString()}`;
         }
         
         if (prevBtn) {
@@ -932,7 +936,7 @@
         const lastUpdated = document.getElementById('last_updated');
         
         if (resultsCount) {
-            resultsCount.textContent = `${PRIORITY_ACCOUNTS_PAGINATION.total_count} priority accounts`;
+            resultsCount.textContent = `${PRIORITY_ACCOUNTS_PAGINATION.total_count.toLocaleString()} priority accounts`;
         }
         
         if (lastUpdated) {
@@ -1623,7 +1627,7 @@
                     current = target;
                     clearInterval(timer);
                 }
-                counter.textContent = Math.round(current);
+                counter.textContent = Math.round(current).toLocaleString();
             }, 16);
         });
     }

--- a/templates/submissions.html
+++ b/templates/submissions.html
@@ -517,9 +517,9 @@
     // Money short format for compact columns
     function fmtMoneyShort(v){
         const n = Number(v || 0);
-        if (n >= 1e9) return '$' + (n/1e9).toFixed(1) + 'B';
-        if (n >= 1e6) return '$' + (n/1e6).toFixed(1) + 'M';
-        if (n >= 1e3) return '$' + Math.round(n/1e3) + 'K';
+        if (n >= 1e9) return '$' + (n/1e9).toLocaleString(undefined, {minimumFractionDigits:1, maximumFractionDigits:1}) + 'B';
+        if (n >= 1e6) return '$' + (n/1e6).toLocaleString(undefined, {minimumFractionDigits:1, maximumFractionDigits:1}) + 'M';
+        if (n >= 1e3) return '$' + Math.round(n/1e3).toLocaleString() + 'K';
         return '$' + Math.round(n).toLocaleString();
     }
     
@@ -586,14 +586,14 @@
             updatePagination([]);
             return;
         }
-        
+
         console.log('Processing', rows.length, 'rows for pagination');
         // Get paginated rows
         const paginatedRows = updatePagination(rows);
         console.log('Got', paginatedRows.length, 'paginated rows for display');
-        
+
         emptyState?.classList.add("hidden");
-        countSpan.textContent = `${rows.length}`;
+        countSpan.textContent = rows.length.toLocaleString();
         
         // Calculate stats for hero and header chips (factual, from rows)
         const stats = {
@@ -690,7 +690,7 @@
         }
 
         emptyState?.classList.add('hidden');
-        if (countSpan) countSpan.textContent = `${rows.length}`;
+        if (countSpan) countSpan.textContent = rows.length.toLocaleString();
 
         // Stats
         const stats = {
@@ -721,7 +721,10 @@
     }
 
     function updateHeaderChips(stats){
-        const set = (id, val) => { const el = document.getElementById(id); if (el) el.textContent = String(val ?? '—'); };
+        const set = (id, val) => {
+            const el = document.getElementById(id);
+            if (el) el.textContent = typeof val === 'number' ? val.toLocaleString() : String(val ?? '—');
+        };
         set('stat_total', stats.total ?? '—');
         set('stat_target', stats.target ?? '—');
         set('stat_in', stats.in ?? '—');
@@ -743,9 +746,9 @@
         const pageEndEl = document.getElementById('page-end');
         const totalCountEl = document.getElementById('total-count');
         
-        if (pageStartEl) pageStartEl.textContent = TOTAL_ITEMS > 0 ? start : 0;
-        if (pageEndEl) pageEndEl.textContent = end;
-        if (totalCountEl) totalCountEl.textContent = TOTAL_ITEMS;
+        if (pageStartEl) pageStartEl.textContent = TOTAL_ITEMS > 0 ? start.toLocaleString() : '0';
+        if (pageEndEl) pageEndEl.textContent = end.toLocaleString();
+        if (totalCountEl) totalCountEl.textContent = TOTAL_ITEMS.toLocaleString();
         
         console.log('Updated pagination display:', start, '-', end, 'of', TOTAL_ITEMS);
         
@@ -837,7 +840,7 @@
         const targetCountEl = document.getElementById('target_count');
         const completionRateEl = document.getElementById('completion_rate');
         
-        if (targetCountEl) targetCountEl.textContent = stats.target || '—';
+        if (targetCountEl) targetCountEl.textContent = stats.target ? stats.target.toLocaleString() : '—';
         if (completionRateEl) {
             const rate = stats.total ? Math.round((stats.processed / stats.total) * 100) : 0;
             completionRateEl.textContent = `${rate}%`;
@@ -913,7 +916,7 @@
         
         function updateSelectionInfo() {
             const selectedCount = document.querySelectorAll('.row-checkbox:checked').length;
-            if (selectedCountEl) selectedCountEl.textContent = selectedCount;
+            if (selectedCountEl) selectedCountEl.textContent = selectedCount.toLocaleString();
             if (selectedInfo) {
                 selectedInfo.classList.toggle('hidden', selectedCount === 0);
             }


### PR DESCRIPTION
## Summary
- add reusable `commafy` Jinja filter
- format dashboard stats, counters, and monetary values with comma separators

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c60e0e8dd0832dbe732795ac8c730c