### PR TITLE
Make dashboard metrics dynamic per mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -711,7 +711,7 @@ def apiClassified():
 def apiPriorityAccounts():
     """API endpoint for Priority Account Review - returns top priority submissions"""
     df, _ = refreshCache()
-    
+
     # Get query parameters
     state = request.args.get("state")
     status = request.args.get("status")
@@ -722,10 +722,28 @@ def apiPriorityAccounts():
     per_page = request.args.get("per_page", default=20, type=int)
     sort_by = request.args.get("sort_by", default="priority_score")
     sort_dir = request.args.get("sort_dir", default="desc")
-    
-    # Apply filters
+    mode = request.args.get("mode")
+
+    # Start with full dataset
     d = df.copy()
-    
+
+    # If a mode is specified, apply mode-specific filters and scoring
+    if mode and mode in MODES:
+        preset = MODES[mode]
+        filters = preset.get("filters", {})
+        weights = preset.get("weights", {})
+        d = apply_hard_filters(d, filters)
+        scounts = Counter(d["primary_risk_state"].fillna("UNK"))
+        rows = []
+        for r in d.to_dict(orient="records"):
+            stat, reasons, s, pscore = classify_for_mode_row(r, weights, filters, scounts)
+            r["appetite_status"] = stat
+            r["appetite_reasons"] = reasons
+            r["priority_score"] = float(pscore) * 10.0  # scale to 0-10 for consistency
+            rows.append(r)
+        d = pd.DataFrame(rows)
+
+    # Apply UI filters
     if state:
         d = d[d["primary_risk_state"].astype(str).str.upper() == state.upper()]
     if status:
@@ -737,11 +755,10 @@ def apiPriorityAccounts():
     if q:
         m = d["account_name"].astype(str).str.contains(q, case=False, na=False)
         d = d[m.fillna(False)]
-    
+
     # Focus on higher-priority submissions for priority review
-    # Show submissions with priority_score >= 1.0 and preferably IN or TARGET status
     d = d[(d["priority_score"] >= 1.0) & (d["appetite_status"].isin(["TARGET", "IN", "OUT"]))]
-    
+
     # Apply sorting
     ascending = sort_dir.lower() == "asc"
     if sort_by in d.columns:
@@ -1323,11 +1340,25 @@ def api_classified_mode():
     else:
         rows.sort(key=lambda r: r.get("priority_score"), reverse=True)
 
+    # Build summary stats for UI metrics
+    status_counts = Counter([r.get("appetite_status") for r in rows])
+    premiums = [r.get("total_premium") for r in rows if r.get("total_premium") is not None]
+    wins = [r.get("winnability") for r in rows if r.get("winnability") is not None]
+    summary = {
+        "total": len(rows),
+        "target": status_counts.get("TARGET", 0),
+        "in": status_counts.get("IN", 0),
+        "out": status_counts.get("OUT", 0),
+        "avg_premium": float(np.mean(premiums)) if premiums else 0.0,
+        "avg_win": float(np.mean(wins)) if wins else 0.0,
+    }
+
     return jsonify({
         "count": len(rows),
         "data": rows,
         "mode": mode,
         "mode_explanation": mode_explanation,
+        "summary": summary,
     })
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -79,29 +79,32 @@
         document.getElementById('avg_premium').textContent = metrics.avgPremium ? '$' + Math.round(metrics.avgPremium/1000) + 'K' : '—';
         document.getElementById('opportunities_count').textContent = metrics.opportunities || '—';
       }
+      window.updateQuickStats = updateQuickStats;
       
-      function simulateActivityFeed() {
-        const activities = [
-          '📋 New submission from Acme Corp - $125K premium',
-          '🎯 High-priority target identified in CA',
-          '✅ Submission #1234 moved to In-Appetite',
-          '📊 Portfolio metrics updated',
-          '🔄 Data refresh completed'
-        ];
-        let currentIndex = 0;
-        
-        setInterval(() => {
-          const feed = document.getElementById('activity_feed');
-          if (feed) {
-            feed.innerHTML = `<span class="text-indigo-300">${activities[currentIndex]}</span>`;
-            currentIndex = (currentIndex + 1) % activities.length;
-          }
+      function updateActivityFeed(rows) {
+        const feed = document.getElementById('activity_feed');
+        if (!feed) return;
+        if (!rows || !rows.length) {
+          feed.innerHTML = '<span class="opacity-75">Monitoring submissions in real-time...</span>';
+          return;
+        }
+        const acts = rows.slice(0,5).map(r => {
+          const emoji = r.appetite_status === 'TARGET' ? '🎯' : (r.appetite_status === 'IN' ? '✅' : '❌');
+          return `${emoji} ${r.account_name || 'Account'} - $${Math.round(r.total_premium || 0).toLocaleString()} premium`;
+        });
+        let idx = 0;
+        clearInterval(window._feedTimer);
+        feed.innerHTML = `<span class="text-indigo-300">${acts[0]}</span>`;
+        window._feedTimer = setInterval(() => {
+          idx = (idx + 1) % acts.length;
+          feed.innerHTML = `<span class="text-indigo-300">${acts[idx]}</span>`;
         }, 3000);
       }
-      
+
+      window.updateActivityFeed = updateActivityFeed;
+
       greet();
       updateQuickStats();
-      simulateActivityFeed();
       
       window.addEventListener('storage', (e) => {
         if(e.key === 'USER_NAME') greet();
@@ -220,7 +223,7 @@
         <button class="action-button hover-lift" onclick="window.location.href='/submissions?status=TARGET'">
             <div class="action-icon">🎯</div>
             <div class="action-label">Review Targets</div>
-            <div class="action-count">{{ tgt_ct }}</div>
+            <div class="action-count" id="action_target_count">{{ tgt_ct }}</div>
         </button>
         <button class="action-button hover-lift" onclick="exportOpportunities()">
             <div class="action-icon">📊</div>
@@ -377,9 +380,6 @@
                 </select>
                 <select class="filter-select" id="state_filter">
                     <option value="">All States</option>
-                    <option value="CA">California</option>
-                    <option value="FL">Florida</option>
-                    <option value="TX">Texas</option>
                 </select>
                 <input type="text" class="filter-input" id="search_filter" placeholder="Search accounts...">
                 <button class="filter-apply-btn">Apply</button>
@@ -570,6 +570,49 @@
         el.textContent = `Last updated ${hh}:${mm}`;
     }
 
+    function updateMetricCards(summary){
+        if(!summary) return;
+        const total = summary.total || 0;
+        const tgt = summary.target || 0;
+        const inCt = summary.in || 0;
+        const outCt = summary.out || 0;
+        const avgPrem = summary.avg_premium || 0;
+
+        const targetEl = document.querySelector('[data-metric="target"] .metric-value');
+        const inEl = document.querySelector('[data-metric="in"] .metric-value');
+        const totalEl = document.querySelector('[data-metric="total"] .metric-value');
+        const outEl = document.querySelector('[data-metric="out"] .metric-value');
+        if(targetEl) targetEl.dataset.target = tgt;
+        if(inEl) inEl.dataset.target = inCt;
+        if(totalEl) totalEl.dataset.target = total;
+        if(outEl) outEl.dataset.target = outCt;
+
+        const pctTgt = total ? Math.round((tgt/total)*100) : 0;
+        const pctIn = total ? Math.round((inCt/total)*100) : 0;
+        const pctOut = total ? Math.round((outCt/total)*100) : 0;
+
+        const tgtBar = document.querySelector('[data-metric="target"] .progress-fill');
+        const tgtText = document.querySelector('[data-metric="target"] .progress-text');
+        const inBar = document.querySelector('[data-metric="in"] .progress-fill');
+        const inText = document.querySelector('[data-metric="in"] .progress-text');
+        const outBar = document.querySelector('[data-metric="out"] .progress-fill');
+        const outText = document.querySelector('[data-metric="out"] .progress-text');
+        const totalText = document.querySelector('[data-metric="total"] .progress-text');
+
+        if(tgtBar) tgtBar.style.width = pctTgt + '%';
+        if(tgtText) tgtText.textContent = `${pctTgt}% of submissions`;
+        if(inBar) inBar.style.width = pctIn + '%';
+        if(inText) inText.textContent = `${pctIn}% of submissions`;
+        if(outBar) outBar.style.width = pctOut + '%';
+        if(outText) outText.textContent = `${pctOut}% of submissions`;
+        if(totalText) totalText.textContent = `Avg premium $${Math.round(avgPrem).toLocaleString()}`;
+
+        const quickTarget = document.getElementById('action_target_count');
+        if (quickTarget) quickTarget.textContent = tgt;
+
+        animateCounters();
+    }
+
     // Worklist view state helpers
     function getWorklistView(){
         try { return localStorage.getItem('WORKLIST_VIEW') || 'list'; } catch(e){ return 'list'; }
@@ -589,6 +632,15 @@
             const sel = document.getElementById("home_mode");
             const mode = (sel?.value && sel.value !== "") ? sel.value : getActiveMode();
             const j = await fetchJSON(`/api/classified_mode?mode=${encodeURIComponent(mode)}`);
+            if (j.summary) {
+                updateMetricCards(j.summary);
+                window._dashboardMetrics = window._dashboardMetrics || {};
+                window._dashboardMetrics.targets = j.summary.target || 0;
+                window._dashboardMetrics.avgPremium = j.summary.avg_premium || 0;
+                window._dashboardMetrics.winRate = (j.summary.avg_win || 0) * 100;
+                window._dashboardMetrics.opportunities = (j.summary.target || 0) + (j.summary.in || 0);
+                if (typeof updateQuickStats === 'function') updateQuickStats();
+            }
             // Fallback if custom yields no rows
             if ((j.count || 0) === 0 && mode === "custom") {
                 const last = localStorage.getItem("LAST_NON_EMPTY_MODE") || "balanced_growth";
@@ -597,6 +649,7 @@
                 if (sel) sel.value = last;
                 const jj = await fetchJSON(`/api/classified_mode?mode=${encodeURIComponent(last)}`);
                 renderWorklistRows(jj.data || [], last);
+                if (typeof updateActivityFeed === 'function') updateActivityFeed(jj.data || []);
                 return;
             }
             if ((j.count || 0) > 0) {
@@ -605,6 +658,7 @@
             // cache rows so view toggle can re-render without refetch
             window._worklistRows = j.data || [];
             renderWorklistRows(window._worklistRows, mode);
+            if (typeof updateActivityFeed === 'function') updateActivityFeed(window._worklistRows);
             updateModeChip();
             updateLastUpdated('worklist_last');
         });
@@ -729,6 +783,7 @@
 
     // Priority Accounts functionality
     let PRIORITY_ACCOUNTS_DATA = [];
+    let PRIORITY_ACCOUNTS_STATES = [];
     let PRIORITY_ACCOUNTS_PAGINATION = {
         page: 1,
         per_page: 20,
@@ -747,6 +802,17 @@
         sort_dir: 'desc'
     };
 
+    function updateStateFilterOptions() {
+        const stateFilter = document.getElementById('state_filter');
+        if (!stateFilter) return;
+        const selected = stateFilter.value;
+        stateFilter.innerHTML = '<option value="">All States</option>' +
+            PRIORITY_ACCOUNTS_STATES.map(s => `<option value="${s}">${s}</option>`).join('');
+        if (selected && PRIORITY_ACCOUNTS_STATES.includes(selected)) {
+            stateFilter.value = selected;
+        }
+    }
+
     async function loadPriorityAccounts(page = 1) {
         const tbody = document.getElementById("acct_body");
         if (!tbody) return;
@@ -759,6 +825,9 @@
                 sort_by: PRIORITY_ACCOUNTS_FILTERS.sort_by,
                 sort_dir: PRIORITY_ACCOUNTS_FILTERS.sort_dir
             });
+
+            const mode = document.getElementById('home_mode')?.value || getActiveMode();
+            if (mode) params.append('mode', mode);
 
             // Add filters if they exist
             if (PRIORITY_ACCOUNTS_FILTERS.state) params.append('state', PRIORITY_ACCOUNTS_FILTERS.state);
@@ -787,6 +856,11 @@
             
             PRIORITY_ACCOUNTS_DATA = response.data || [];
             PRIORITY_ACCOUNTS_PAGINATION = response.pagination || PRIORITY_ACCOUNTS_PAGINATION;
+
+            if (!PRIORITY_ACCOUNTS_FILTERS.state) {
+                PRIORITY_ACCOUNTS_STATES = Array.from(new Set(PRIORITY_ACCOUNTS_DATA.map(a => a.primary_risk_state).filter(Boolean))).sort();
+                updateStateFilterOptions();
+            }
             
             // Render table
             renderPriorityAccountsTable();
@@ -1328,6 +1402,10 @@
                 setActiveMode(e.target.value);
                 updateModeChip();
                 loadHome();
+                PRIORITY_ACCOUNTS_FILTERS.state = '';
+                const sf = document.getElementById('state_filter');
+                if (sf) sf.value = '';
+                loadPriorityAccounts();
             }
         });
     }


### PR DESCRIPTION
## Summary
- compute summary counts in `/api/classified_mode` for use in UI metrics
- allow `/api/priority-accounts` to filter and score by selected data mode
- update dashboard to refresh KPI tiles and priority table when mode changes
- populate priority account state filter and activity feed from live data

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c60ccc4858832d9ae3331dab61bde1