### PR TITLE
Format large numbers with thousand separators

### DIFF
--- a/app.py
+++ b/app.py
@@ -52,6 +52,16 @@ def dateformat(value, format='%b %d, %Y'):
     
     return '—'
 
+# Custom Jinja2 filter for comma formatting of large numbers
+@app.template_filter('commafy')
+def commafy(value, decimals=0):
+    """Format a number with thousands separators."""
+    try:
+        fmt = f"{float(value):,.{decimals}f}"
+        return fmt
+    except (TypeError, ValueError):
+        return value
+
 FEDERATO_TOKEN = os.environ.get("FEDERATO_TOKEN")
 CLIENT_ID = os.environ.get("FEDERATO_CLIENT_ID")
 CLIENT_SECRET = os.environ.get("FEDERATO_CLIENT_SECRET")

--- a/templates/detail.html
+++ b/templates/detail.html
@@ -42,11 +42,11 @@
   <!-- Quick Assessment Summary -->
   <div class="grid grid-cols-1 md:grid-cols-4 gap-4 p-4 bg-white bg-opacity-5 rounded-lg">
     <div class="text-center">
-      <div class="text-lg font-semibold text-emerald-300">${{ '%.0f'|format(item.total_premium or 0) }}</div>
+      <div class="text-lg font-semibold text-emerald-300">${{ item.total_premium | commafy(2) }}</div>
       <div class="text-xs opacity-75">Premium</div>
     </div>
     <div class="text-center">
-      <div class="text-lg font-semibold">${{ (item.tiv / 1000000) | round(1) }}M</div>
+      <div class="text-lg font-semibold">${{ (item.tiv / 1000000) | commafy(1) }}M</div>
       <div class="text-xs opacity-75">TIV</div>
     </div>
     <div class="text-center">
@@ -93,7 +93,7 @@
         <div class="kv">
           <span>Loss Value</span>
           <b class="{% if item.loss_value > 100000 %}text-rose-300{% else %}text-emerald-300{% endif %}">
-            ${{ '%.0f'|format(item.loss_value or 0) }}
+            ${{ item.loss_value | commafy(2) }}
           </b>
         </div>
         <div class="kv">

--- a/templates/index.html
+++ b/templates/index.html
@@ -74,10 +74,14 @@
       function updateQuickStats() {
         // This will be populated by the main script
         const metrics = window._dashboardMetrics || {};
-        document.getElementById('active_targets').textContent = metrics.targets || '—';
+        document.getElementById('active_targets').textContent =
+          metrics.targets ? Number(metrics.targets).toLocaleString() : '—';
         document.getElementById('win_rate').textContent = metrics.winRate ? Math.round(metrics.winRate) + '%' : '—%';
-        document.getElementById('avg_premium').textContent = metrics.avgPremium ? '$' + Math.round(metrics.avgPremium/1000) + 'K' : '—';
-        document.getElementById('opportunities_count').textContent = metrics.opportunities || '—';
+        document.getElementById('avg_premium').textContent = metrics.avgPremium
+          ? '$' + Math.round(metrics.avgPremium / 1000).toLocaleString() + 'K'
+          : '—';
+        document.getElementById('opportunities_count').textContent =
+          metrics.opportunities ? Number(metrics.opportunities).toLocaleString() : '—';
       }
       
       function simulateActivityFeed() {
@@ -570,6 +574,14 @@
         el.textContent = `Last updated ${hh}:${mm}`;
     }
 
+    function formatCurrency(val){
+        const n = Number(val || 0);
+        const opts = n % 1 === 0
+            ? {minimumFractionDigits:0, maximumFractionDigits:0}
+            : {minimumFractionDigits:2, maximumFractionDigits:2};
+        return '$' + n.toLocaleString(undefined, opts);
+    }
+
     // Worklist view state helpers
     function getWorklistView(){
         try { return localStorage.getItem('WORKLIST_VIEW') || 'list'; } catch(e){ return 'list'; }
@@ -669,7 +681,7 @@
             <a href="/detail/${r.id}?mode=${encodeURIComponent(mode)}" class="row">
               <div class="row-main">
                 <div class="row-title">${r.account_name || "-"}</div>
-                <div class="row-sub">${r.primary_risk_state || "-"} · ${r.line_of_business || "-"} · $${Math.round(r.total_premium || 0).toLocaleString()}</div>
+                <div class="row-sub">${r.primary_risk_state || "-"} · ${r.line_of_business || "-"} · ${formatCurrency(r.total_premium)}</div>
               </div>
               <div class="row-badges">
                 ${badge(r.appetite_status)}
@@ -690,7 +702,7 @@
               </div>
               <div class="work-card-sub">${r.primary_risk_state || '-'} · ${r.line_of_business || '-'} </div>
               <div class="work-card-meta">
-                <span>$${Math.round(r.total_premium || 0).toLocaleString()} premium</span>
+                <span>${formatCurrency(r.total_premium)} premium</span>
                 <span>Score ${Number(r.priority_score || 0).toFixed(2)}</span>
               </div>
             </a>`).join('')}
@@ -716,7 +728,7 @@
                   <div class="k-title">${r.account_name || '-'}</div>
                   <div class="k-sub">${r.primary_risk_state || '-'} · ${r.line_of_business || '-'}</div>
                   <div class="k-meta">
-                    <span>$${Math.round(r.total_premium || 0).toLocaleString()}</span>
+                    <span>${formatCurrency(r.total_premium)}</span>
                     <span>Score ${Number(r.priority_score || 0).toFixed(1)}</span>
                   </div>
                 </a>`).join('')}
@@ -843,9 +855,8 @@
             const priorityClass = account.priority_score >= 7 ? 'priority-high' : 
                                 account.priority_score >= 4 ? 'priority-medium' : 'priority-low';
             
-            const premiumFormatted = account.total_premium ? 
-                new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', minimumFractionDigits: 0 })
-                    .format(account.total_premium) : '—';
+            const premiumFormatted = account.total_premium != null ?
+                formatCurrency(account.total_premium) : '—';
 
             return `
                 <tr class="table-row hover:bg-white/5 transition-all duration-200" data-account-id="${account.id}">
@@ -905,7 +916,7 @@
         const nextBtn = document.getElementById('next_page');
         
         if (paginationInfo) {
-            paginationInfo.textContent = `Page ${PRIORITY_ACCOUNTS_PAGINATION.page} of ${PRIORITY_ACCOUNTS_PAGINATION.total_pages}`;
+            paginationInfo.textContent = `Page ${PRIORITY_ACCOUNTS_PAGINATION.page.toLocaleString()} of ${PRIORITY_ACCOUNTS_PAGINATION.total_pages.toLocaleString()}`;
         }
         
         if (prevBtn) {
@@ -932,7 +943,7 @@
         const lastUpdated = document.getElementById('last_updated');
         
         if (resultsCount) {
-            resultsCount.textContent = `${PRIORITY_ACCOUNTS_PAGINATION.total_count} priority accounts`;
+            resultsCount.textContent = `${PRIORITY_ACCOUNTS_PAGINATION.total_count.toLocaleString()} priority accounts`;
         }
         
         if (lastUpdated) {
@@ -1623,7 +1634,7 @@
                     current = target;
                     clearInterval(timer);
                 }
-                counter.textContent = Math.round(current);
+                counter.textContent = Math.round(current).toLocaleString();
             }, 16);
         });
     }

--- a/templates/insights.html
+++ b/templates/insights.html
@@ -103,6 +103,14 @@
         return [header, ...rows].join("\n");
     }
 
+    function formatCurrency(val){
+        const n = Number(val || 0);
+        const opts = n % 1 === 0
+            ? {minimumFractionDigits:0, maximumFractionDigits:0}
+            : {minimumFractionDigits:2, maximumFractionDigits:2};
+        return '$' + n.toLocaleString(undefined, opts);
+    }
+
     // Fullscreen
     function openFullscreen(node) {
         const host = document.getElementById("fs_host");
@@ -1341,11 +1349,7 @@
                             r.primary_risk_state || "-"
                         } · ${
                             r.line_of_business || "-"
-                        }<br/>Premium $${Math.round(
-                            r.total_premium || 0
-                        ).toLocaleString()} · TIV $${Math.round(
-                            r.tiv || 0
-                        ).toLocaleString()} · Win ${(win || 0).toFixed(0)}%`;
+                        }<br/>Premium ${formatCurrency(r.total_premium)} · TIV ${formatCurrency(r.tiv)} · Win ${(win || 0).toFixed(0)}%`;
                     },
                 },
                 xAxis3D: axisName(

--- a/templates/submissions.html
+++ b/templates/submissions.html
@@ -513,14 +513,25 @@
             return res.json();
         }
     }
-    
+
+    function formatCurrency(v){
+        const n = Number(v || 0);
+        const opts = n % 1 === 0
+            ? {minimumFractionDigits:0, maximumFractionDigits:0}
+            : {minimumFractionDigits:2, maximumFractionDigits:2};
+        return '$' + n.toLocaleString(undefined, opts);
+    }
+
     // Money short format for compact columns
     function fmtMoneyShort(v){
         const n = Number(v || 0);
-        if (n >= 1e9) return '$' + (n/1e9).toFixed(1) + 'B';
-        if (n >= 1e6) return '$' + (n/1e6).toFixed(1) + 'M';
-        if (n >= 1e3) return '$' + Math.round(n/1e3) + 'K';
-        return '$' + Math.round(n).toLocaleString();
+        const fmt = (num) => num % 1 === 0
+            ? num.toLocaleString()
+            : num.toLocaleString(undefined, {minimumFractionDigits:2, maximumFractionDigits:2});
+        if (n >= 1e9) return '$' + fmt(n/1e9) + 'B';
+        if (n >= 1e6) return '$' + fmt(n/1e6) + 'M';
+        if (n >= 1e3) return '$' + fmt(n/1e3) + 'K';
+        return '$' + fmt(n);
     }
     
     if (typeof window.withLoading === 'undefined') {
@@ -586,14 +597,14 @@
             updatePagination([]);
             return;
         }
-        
+
         console.log('Processing', rows.length, 'rows for pagination');
         // Get paginated rows
         const paginatedRows = updatePagination(rows);
         console.log('Got', paginatedRows.length, 'paginated rows for display');
-        
+
         emptyState?.classList.add("hidden");
-        countSpan.textContent = `${rows.length}`;
+        countSpan.textContent = rows.length.toLocaleString();
         
         // Calculate stats for hero and header chips (factual, from rows)
         const stats = {
@@ -690,7 +701,7 @@
         }
 
         emptyState?.classList.add('hidden');
-        if (countSpan) countSpan.textContent = `${rows.length}`;
+        if (countSpan) countSpan.textContent = rows.length.toLocaleString();
 
         // Stats
         const stats = {
@@ -711,7 +722,7 @@
                     <div class=\"font-medium\">${r.account_name || '-'}</div>
                     ${r.appetite_status ? `<span class=\"pill ${r.appetite_status==='TARGET'?'pill-indigo': (r.appetite_status==='IN'?'pill-emerald':'pill-rose')}\">${r.appetite_status}</span>` : ''}
                 </div>
-                <div class=\"text-sm opacity-80 mb-2\">${r.primary_risk_state || '-'} · ${r.line_of_business || '-'} · $${Math.round(r.total_premium||0).toLocaleString()}</div>
+                <div class=\"text-sm opacity-80 mb-2\">${r.primary_risk_state || '-'} · ${r.line_of_business || '-'} · ${formatCurrency(r.total_premium)}</div>
                 <div class=\"flex items-center justify-between text-xs opacity-90\">
                     <span>Score ${Number(r.priority_score||0).toFixed(1)}</span>
                     <span>Win ${Number((r.winnability>1?r.winnability:(r.winnability||0)*100)).toFixed(0)}%</span>
@@ -721,7 +732,10 @@
     }
 
     function updateHeaderChips(stats){
-        const set = (id, val) => { const el = document.getElementById(id); if (el) el.textContent = String(val ?? '—'); };
+        const set = (id, val) => {
+            const el = document.getElementById(id);
+            if (el) el.textContent = typeof val === 'number' ? val.toLocaleString() : String(val ?? '—');
+        };
         set('stat_total', stats.total ?? '—');
         set('stat_target', stats.target ?? '—');
         set('stat_in', stats.in ?? '—');
@@ -743,9 +757,9 @@
         const pageEndEl = document.getElementById('page-end');
         const totalCountEl = document.getElementById('total-count');
         
-        if (pageStartEl) pageStartEl.textContent = TOTAL_ITEMS > 0 ? start : 0;
-        if (pageEndEl) pageEndEl.textContent = end;
-        if (totalCountEl) totalCountEl.textContent = TOTAL_ITEMS;
+        if (pageStartEl) pageStartEl.textContent = TOTAL_ITEMS > 0 ? start.toLocaleString() : '0';
+        if (pageEndEl) pageEndEl.textContent = end.toLocaleString();
+        if (totalCountEl) totalCountEl.textContent = TOTAL_ITEMS.toLocaleString();
         
         console.log('Updated pagination display:', start, '-', end, 'of', TOTAL_ITEMS);
         
@@ -837,7 +851,7 @@
         const targetCountEl = document.getElementById('target_count');
         const completionRateEl = document.getElementById('completion_rate');
         
-        if (targetCountEl) targetCountEl.textContent = stats.target || '—';
+        if (targetCountEl) targetCountEl.textContent = stats.target ? stats.target.toLocaleString() : '—';
         if (completionRateEl) {
             const rate = stats.total ? Math.round((stats.processed / stats.total) * 100) : 0;
             completionRateEl.textContent = `${rate}%`;
@@ -913,7 +927,7 @@
         
         function updateSelectionInfo() {
             const selectedCount = document.querySelectorAll('.row-checkbox:checked').length;
-            if (selectedCountEl) selectedCountEl.textContent = selectedCount;
+            if (selectedCountEl) selectedCountEl.textContent = selectedCount.toLocaleString();
             if (selectedInfo) {
                 selectedInfo.classList.toggle('hidden', selectedCount === 0);
             }


### PR DESCRIPTION
## Summary
- add reusable `commafy` Jinja filter
- format dashboard stats, counters, and monetary values with comma separators
- pad currency amounts so cents always show two digits

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c60e0e8dd0832dbe732795ac8c730c